### PR TITLE
Improve test reliability by resetting the pre-state in test_redisqueue

### DIFF
--- a/redisqueue/mock.py
+++ b/redisqueue/mock.py
@@ -34,6 +34,11 @@ class MockRedisQueue(RedisQueue):
 
         return self.connected
 
+    def disconnect(self, **kwargs):
+        self.connected = False
+
+        return self.connected
+
     def clear(self):
         self._items = []
         self._item_lock = []

--- a/tests/test_redisqueue.py
+++ b/tests/test_redisqueue.py
@@ -43,6 +43,7 @@ mock_queue = MockRedisQueue('mock_queue', MockTask)
 
 
 def test_mock_queue_connection():
+    mock_queue.disconnect()
     assert mock_queue.connected is False
 
     with pytest.raises(QueueNotConnectedError):


### PR DESCRIPTION
This PR aims to improve the reliability of the test `test_mock_queue_connection` by cleaning the pre-state.
The test can fail if the pre-state is polluted:
```
>       assert mock_queue.connected is False
E       assert True is False
E        +  where True = <redisqueue.mock.MockRedisQueue object at 0x7f42458d4130>.connected

tests/test_redisqueue.py:46: AssertionError
```