### PR TITLE
Fix Order-Dependent Brittle Tests (OD-Brit)

### DIFF
--- a/tests/test_redisqueue.py
+++ b/tests/test_redisqueue.py
@@ -59,6 +59,8 @@ def test_mock_queue_connection():
 
 
 def test_mock_queue_put_get():
+    mock_queue.connect()
+    mock_queue.clear()
     assert mock_queue.qsize() == 0
 
     task = MockTask()
@@ -75,6 +77,8 @@ def test_mock_queue_put_get():
 
 
 def test_mock_queue_unique():
+    mock_queue.connect()
+    mock_queue.clear()
     assert mock_queue.qsize() == 0
 
     task = MockTask()
@@ -98,6 +102,7 @@ def test_mock_queue_unique():
 
 
 def test_mock_queue_get_put_same_task():
+    mock_queue.connect()
     mock_queue.clear()
 
     task = MockTask()


### PR DESCRIPTION
Ran pytest --maxfail=1 --reruns 3 and noticed QueueNotConnectedError from 
- test_mock_queue_unique
- test_mock_queue_put_get
- test_mock_queue_get_put_same_task

These tests were found to be flaky, causing error when the Queue was not connected.

The solution is to explicitly connect the Queues, and clear the queue at the beginning to prevent any leftover tasks from influencing the test outcome.